### PR TITLE
API(config): Config Patch Endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           name: odyssey_x86_64
           path: odyssey_x86_64/*
 
-      - uses: ncipollo/release-action@v1.14.0
+      - uses: ncipollo/release-action@v1.18.0
         if: github.ref == 'refs/heads/main'
         with:
           artifacts: "odyssey*.tar.gz"
@@ -79,7 +79,7 @@ jobs:
           generateReleaseNotes: true
           commit: ${{github.sha}}
 
-      - uses: ncipollo/release-action@v1.14.0
+      - uses: ncipollo/release-action@v1.18.0
         if: github.ref != 'refs/heads/main'
         with:
           artifacts: "*odyssey*.tar.gz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 clap = { version = "4.1.6", features = ["derive"] }
 cross = "0.2.5"
 config = "0.13.4"
+toml_edit = {version = "0.22.24", features=["serde"]}
+optional_struct = "0.5.2"
 serde = "1.0"
 serde_yaml = "0.9"
 zip = "1.1.1"

--- a/resources/default.toml
+++ b/resources/default.toml
@@ -1,0 +1,69 @@
+# This is the default Odyssey configuration file for the Prometheus MSLA. It is
+# meant to be paired with the latest Prometheus MSLA klipper config.
+
+# This section holds the config fields related to the printer, such as its serial
+# connection and its frame buffer specs
+[printer]
+serial = "/home/pi/printer_data/comms/klippy.serial"
+baudrate = 0
+max_z = 300
+default_lift = 10
+default_up_speed = 3.4
+default_down_speed = 3.4
+default_wait_before_exposure = 2.2
+default_wait_after_exposure = 1.5
+pause_lift = 100
+
+# This section holds fields pertaining to the display used by the printer
+[display]
+frame_buffer = "/dev/fb0"
+bit_depth = [5, 6, 5]
+screen_width = 6480
+screen_height = 3600
+
+# This section holds fields pertaining to the Gcode used to drive the machine's
+# hardware, and signal between the board and Odyssey
+[gcode]
+boot = """
+G90
+"""
+shutdown = """
+M84 
+UVLED_OFF 
+"""
+home_command = """
+HOME_AXIS
+"""
+move_command = """
+MOVE_PLATE Z={z} F={speed}
+"""
+print_start = """
+HOME_AXIS
+SET_PRINT_STATS_INFO TOTAL_LAYER={total_layers}
+"""
+print_end = """
+MOVE_PLATE Z={max_z} F=400
+"""
+layer_start = """
+SET_PRINT_STATS_INFO CURRENT_LAYER={layer}
+"""
+cure_start = """
+UVLED_ON
+"""
+cure_end = """
+UVLED_OFF
+"""
+move_sync = "Z_move_comp"
+move_timeout = 60
+status_check = """
+status
+"""
+status_desired = "Klipper state: Ready"
+
+# This section holds fields pertaining to the Odyseey API, such as the port number
+# and where to store uploaded .sl1 files
+[api]
+upload_path = "/home/pi/printer_data/gcodes"
+# glob pattern for finding files in mounted USB devices, if present
+usb_glob = "/media/usb*/*.sl1"
+port = 12357

--- a/src/api.rs
+++ b/src/api.rs
@@ -14,7 +14,7 @@ use poem::{
     error::{
         BadRequest, GetDataError, InternalServerError, MethodNotAllowedError, NotImplemented,
         ServiceUnavailable, Unauthorized,
-    }, http::StatusCode, listener::TcpListener, middleware::Cors, web::Data, EndpointExt, Response, Result, Route, Server
+    }, listener::TcpListener, middleware::Cors, web::Data, EndpointExt, Response, Result, Route, Server
 };
 use poem_openapi::{
     param::Query,

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,11 +10,16 @@ use std::{
 
 use glob::glob;
 use itertools::Itertools;
+use optional_struct::Applicable;
 use poem::{
     error::{
         BadRequest, GetDataError, InternalServerError, MethodNotAllowedError, NotImplemented,
         ServiceUnavailable, Unauthorized,
-    }, listener::TcpListener, middleware::Cors, web::Data, EndpointExt, Response, Result, Route, Server
+    },
+    listener::TcpListener,
+    middleware::Cors,
+    web::Data,
+    EndpointExt, Response, Result, Route, Server,
 };
 use poem_openapi::{
     param::Query,
@@ -29,7 +34,6 @@ use tokio::{
     time::interval,
 };
 use tokio_util::sync::CancellationToken;
-use optional_struct::Applicable;
 
 use crate::{
     api_objects::{
@@ -136,10 +140,14 @@ impl Api {
     }
 
     #[oai(path = "/config", method = "patch")]
-    async fn patch_config(&self, Data(full_config): Data<&Configuration>, Json(patch_config): Json<UpdateConfiguration>) -> Result<Json<Configuration>> {
+    async fn patch_config(
+        &self,
+        Data(full_config): Data<&Configuration>,
+        Json(patch_config): Json<UpdateConfiguration>,
+    ) -> Result<Json<Configuration>> {
         let ammend_config = patch_config.build(full_config.clone());
         Configuration::overwrite_file(&ammend_config)?;
-        
+
         Ok(Json(ammend_config))
     }
 
@@ -618,8 +626,10 @@ pub async fn start_api(
         .data(full_config.clone())
         .data(configuration.clone())
         .catch_all_error(|err| async move {
-            log::error!("{}",err);
-            Response::builder().status(err.status()).body(err.to_string())
+            log::error!("{}", err);
+            Response::builder()
+                .status(err.status())
+                .body(err.to_string())
         })
         .with(Cors::new());
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,7 +1,7 @@
 use poem_openapi::Object;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use std::{error::Error, fmt::Debug, fs, io, sync::Arc, time::SystemTime};
+use std::{error::Error, fmt::Debug, fs, io, sync::Arc};
 use optional_struct::*;
 
 #[optional_struct(UpdatePrinterConfig)]
@@ -101,19 +101,14 @@ impl Configuration {
 
         let timestamp = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?.as_secs();
 
-        log::warn!("checking {} for existing file", config_file);
+        log::info!("Writing config to {}", config_file);
 
         if fs::exists(config_file)? {
-            log::warn!("{} exists", config_file);
-            fs::rename(config_file, format!("{}.{}.old",config_file,timestamp)).map_err(|err| io::Error::new(err.kind(), format!("Unable to backup existing config file {:?}", err)))?;
+            let old_config = format!("{}.{}.old",config_file,timestamp);
+            log::info!("Moving existing config file to {}", old_config);
+            fs::rename(config_file, old_config).map_err(|err| io::Error::new(err.kind(), format!("Unable to backup existing config file {:?}", err)))?;
         }
-
-        //fs::exists(config_file).and_then(|_| fs::rename(config_file, format!("{}.{}",timestamp,config_file)))?;
-
         
-        log::warn!("overwriting file {} with new content", config_file);
-
-
         fs::write(config_file, content)?;
 
         Ok(())

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -88,11 +88,11 @@ impl Configuration {
     pub fn overwrite_file(config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {
         
         if let Some(config_file) = &config.config_file.clone() {
-            return Configuration::write_to_file(config_file, config);
+            Configuration::write_to_file(config_file, config)
         }
         else {
             log::error!("Config destination unknown, unable to save changes");
-            return Err(io::Error::new(io::ErrorKind::NotFound, "config_file not set on Configuration struct").into());
+            Err(io::Error::new(io::ErrorKind::NotFound, "config_file not set on Configuration struct").into())
         }
     }
     pub fn write_to_file(config_file: &String, config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,7 +1,10 @@
-use config::{Config, ConfigError, Environment, File};
 use poem_openapi::Object;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use std::{error::Error, fmt::Debug, fs, io, sync::Arc, time::SystemTime};
+use optional_struct::*;
 
+#[optional_struct(UpdatePrinterConfig)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct PrinterConfig {
     pub serial: String,
@@ -15,6 +18,7 @@ pub struct PrinterConfig {
     pub pause_lift: f64,
 }
 
+#[optional_struct(UpdateDisplayConfig)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct DisplayConfig {
     pub frame_buffer: String,
@@ -23,6 +27,7 @@ pub struct DisplayConfig {
     pub screen_height: u32,
 }
 
+#[optional_struct(UpdateGcodeConfig)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct GcodeConfig {
     pub boot: String,
@@ -40,6 +45,7 @@ pub struct GcodeConfig {
     pub status_desired: String,
 }
 
+#[optional_struct(UpdateApiConfig)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct ApiConfig {
     pub upload_path: String,
@@ -47,21 +53,72 @@ pub struct ApiConfig {
     pub port: u16,
 }
 
+#[optional_struct(UpdateConfiguration)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
 pub struct Configuration {
+    #[optional_wrap]
+    #[optional_rename(UpdatePrinterConfig)]
     pub printer: PrinterConfig,
+
+    #[optional_wrap]
+    #[optional_rename(UpdateGcodeConfig)]
     pub gcode: GcodeConfig,
+
+    #[optional_wrap]
+    #[optional_rename(UpdateApiConfig)]
     pub api: ApiConfig,
+
+    #[optional_wrap]
+    #[optional_rename(UpdateDisplayConfig)]
     pub display: DisplayConfig,
+
+    
+    #[serde(skip_serializing)]
+    pub config_file: Option<String>
 }
 
 impl Configuration {
-    pub fn from_file(config_file: String) -> Result<Self, ConfigError> {
-        let s = Config::builder()
-            .add_source(File::with_name(config_file.as_str()).required(true))
-            .add_source(Environment::with_prefix("odyssey"))
-            .build()?;
+    pub fn from_file(config_file: String) -> Result<Self, Box<dyn Error>> {
+        let mut config: Configuration = serde_yaml::from_reader(io::BufReader::new(fs::File::open(&config_file)?))?;
+        config.config_file = Some(config_file);
 
-        s.try_deserialize()
+        Ok(config)
     }
+
+    pub fn overwrite_file(config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {
+        
+        if let Some(config_file) = &config.config_file.clone() {
+            return Configuration::write_to_file(config_file, config);
+        }
+        else {
+            log::error!("Config destination unknown, unable to save changes");
+            return Err(io::Error::new(io::ErrorKind::NotFound, "config_file not set on Configuration struct").into());
+        }
+    }
+    pub fn write_to_file(config_file: &String, config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {
+            
+        let content = serde_yaml::to_string(&config).unwrap();
+
+        let timestamp = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?.as_secs();
+
+        log::warn!("checking {} for existing file", config_file);
+
+        if fs::exists(config_file)? {
+            log::warn!("{} exists", config_file);
+            fs::rename(config_file, format!("{}.{}.old",config_file,timestamp)).map_err(|err| io::Error::new(err.kind(), format!("Unable to backup existing config file {:?}", err)))?;
+        }
+
+        //fs::exists(config_file).and_then(|_| fs::rename(config_file, format!("{}.{}",timestamp,config_file)))?;
+
+        
+        log::warn!("overwriting file {} with new content", config_file);
+
+
+        fs::write(config_file, content)?;
+
+        Ok(())
+    }
+
 }
+
+pub type LockedConfig = Arc<RwLock<Configuration>>;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,8 +1,8 @@
+use optional_struct::*;
 use poem_openapi::Object;
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 use std::{error::Error, fmt::Debug, fs, io, sync::Arc};
-use optional_struct::*;
+use tokio::sync::RwLock;
 
 #[optional_struct(UpdatePrinterConfig)]
 #[derive(Clone, Debug, Serialize, Deserialize, Object)]
@@ -72,48 +72,58 @@ pub struct Configuration {
     #[optional_rename(UpdateDisplayConfig)]
     pub display: DisplayConfig,
 
-    
     #[serde(skip_serializing)]
-    pub config_file: Option<String>
+    pub config_file: Option<String>,
 }
 
 impl Configuration {
     pub fn from_file(config_file: String) -> Result<Self, Box<dyn Error>> {
-        let mut config: Configuration = serde_yaml::from_reader(io::BufReader::new(fs::File::open(&config_file)?))?;
+        let mut config: Configuration =
+            serde_yaml::from_reader(io::BufReader::new(fs::File::open(&config_file)?))?;
         config.config_file = Some(config_file);
 
         Ok(config)
     }
 
-    pub fn overwrite_file(config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {
-        
+    pub fn overwrite_file(config: &Configuration) -> Result<(), Box<dyn Error + Send + Sync>> {
         if let Some(config_file) = &config.config_file.clone() {
             Configuration::write_to_file(config_file, config)
-        }
-        else {
+        } else {
             log::error!("Config destination unknown, unable to save changes");
-            Err(io::Error::new(io::ErrorKind::NotFound, "config_file not set on Configuration struct").into())
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "config_file not set on Configuration struct",
+            )
+            .into())
         }
     }
-    pub fn write_to_file(config_file: &String, config: &Configuration) -> Result<(),Box<dyn Error + Send + Sync>> {
-            
+    pub fn write_to_file(
+        config_file: &String,
+        config: &Configuration,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let content = serde_yaml::to_string(&config).unwrap();
 
-        let timestamp = std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)?.as_secs();
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)?
+            .as_secs();
 
         log::info!("Writing config to {}", config_file);
 
         if fs::exists(config_file)? {
-            let old_config = format!("{}.{}.old",config_file,timestamp);
+            let old_config = format!("{}.{}.old", config_file, timestamp);
             log::info!("Moving existing config file to {}", old_config);
-            fs::rename(config_file, old_config).map_err(|err| io::Error::new(err.kind(), format!("Unable to backup existing config file {:?}", err)))?;
+            fs::rename(config_file, old_config).map_err(|err| {
+                io::Error::new(
+                    err.kind(),
+                    format!("Unable to backup existing config file {:?}", err),
+                )
+            })?;
         }
-        
+
         fs::write(config_file, content)?;
 
         Ok(())
     }
-
 }
 
 pub type LockedConfig = Arc<RwLock<Configuration>>;

--- a/src/display.rs
+++ b/src/display.rs
@@ -104,19 +104,19 @@ impl PrintDisplay {
         vec![0x00; (self.config.screen_width * self.config.screen_height) as usize]
     }
 
-    pub fn new(config: DisplayConfig) -> PrintDisplay {
+    pub fn new(config: &DisplayConfig) -> PrintDisplay {
         PrintDisplay {
             frame_buffer: WrappedFramebuffer {
                 frame_buffer: Framebuffer::new(config.frame_buffer.clone()).ok(),
                 fb_path: config.frame_buffer.clone(),
             },
-            config,
+            config: config.clone(),
         }
     }
 }
 
 impl Clone for PrintDisplay {
     fn clone(&self) -> Self {
-        Self::new(self.config.clone())
+        Self::new(&self.config.clone())
     }
 }

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast;
 use tokio::time::{interval, sleep, Duration};
 
 use crate::api_objects::PhysicalState;
-use crate::configuration::{GcodeConfig};
+use crate::configuration::GcodeConfig;
 use crate::printer::HardwareControl;
 
 pub struct Gcode {

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast;
 use tokio::time::{interval, sleep, Duration};
 
 use crate::api_objects::PhysicalState;
-use crate::configuration::{Configuration, GcodeConfig};
+use crate::configuration::{GcodeConfig};
 use crate::printer::HardwareControl;
 
 pub struct Gcode {
@@ -21,12 +21,12 @@ pub struct Gcode {
 
 impl Gcode {
     pub fn new(
-        config: Configuration,
+        config: &GcodeConfig,
         serial_receiver: broadcast::Receiver<String>,
         serial_sender: broadcast::Sender<String>,
     ) -> Gcode {
         Gcode {
-            config: config.gcode,
+            config: config.clone(),
             state: PhysicalState {
                 z: 0.0,
                 z_microns: 0,

--- a/src/shutdown_handler.rs
+++ b/src/shutdown_handler.rs
@@ -4,6 +4,12 @@ pub struct ShutdownHandler {
     pub cancellation_token: CancellationToken,
 }
 
+impl Default for ShutdownHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ShutdownHandler {
     pub fn new() -> Self {
         let cancellation_token = CancellationToken::new();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,6 +6,7 @@ pub static RESOURCE_DIR: &str = "resources";
 pub static UPLOAD_DIR: &str = "uploads";
 pub static CARGO_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+#[allow(dead_code)]
 pub fn default_test_configuration() -> Configuration {
     Configuration {
         config_file: Some("".to_owned()),
@@ -59,6 +60,7 @@ pub fn test_resource_path(resource_file: String) -> String {
     format!("{CARGO_DIR}/{TEST_RESOURCE_DIR}/{resource_file}")
 }
 
+#[allow(dead_code)]
 pub fn upload_path() -> String {
     format!("{CARGO_DIR}/{UPLOAD_DIR}")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,11 +2,13 @@ use odyssey::configuration::{ApiConfig, Configuration, DisplayConfig, GcodeConfi
 
 #[allow(unused_variables)]
 pub static TEST_RESOURCE_DIR: &str = "tests/resources";
+pub static RESOURCE_DIR: &str = "resources";
 pub static UPLOAD_DIR: &str = "uploads";
 pub static CARGO_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 pub fn default_test_configuration() -> Configuration {
     Configuration {
+        config_file: Some("".to_owned()),
         printer: PrinterConfig {
             serial: String::from("/dev/null"),
             baudrate: 250000,
@@ -45,6 +47,11 @@ pub fn default_test_configuration() -> Configuration {
             screen_height: 1080,
         },
     }
+}
+
+#[allow(dead_code)]
+pub fn resource_path(resource_file: String) -> String {
+    format!("{CARGO_DIR}/{RESOURCE_DIR}/{resource_file}")
 }
 
 #[allow(dead_code)]

--- a/tests/no_hardware_mode.rs
+++ b/tests/no_hardware_mode.rs
@@ -1,6 +1,5 @@
 use std::{fs, time::Duration};
 
-use cross::temp;
 use odyssey::{
     api,
     api_objects::PrinterState,

--- a/tests/no_hardware_mode.rs
+++ b/tests/no_hardware_mode.rs
@@ -43,16 +43,10 @@ fn no_hardware_mode() {
     let temp_fb = temp_dir.path().join("mockFb");
     fs::File::create(&temp_fb).expect("Unable to generate mock FrameBuffer file");
 
-
-    //let temp_config = tempfile::Builder::new();
-
     log::info!("Write frames to {}", temp_fb.display());
 
     let (serial_read_sender, serial_read_receiver) = broadcast::channel(200);
     let (serial_write_sender, serial_write_receiver) = broadcast::channel(200);
-
-//    let configuration =
-//        hardwareless_config(temp_fb.path().as_os_str().to_str().unwrap().to_owned());
 
     let mut configuration = Configuration::from_file(test_resource_path("default.yaml".to_owned())).expect("Config could not be parsed");
 
@@ -162,13 +156,3 @@ fn build_runtime() -> Runtime {
         .build()
         .expect("Unable to start Tokio runtime")
 }
-/*
-fn hardwareless_config(framebuffer_filename: String) -> Configuration {
-    let mut default_config = common::default_test_configuration();
-
-    default_config.display.frame_buffer = framebuffer_filename;
-    default_config.printer.serial = String::from("n/a");
-
-    default_config
-}
-*/

--- a/tests/no_hardware_mode.rs
+++ b/tests/no_hardware_mode.rs
@@ -1,5 +1,6 @@
 use std::{fs, time::Duration};
 
+use crate::common::test_resource_path;
 use odyssey::{
     api,
     api_objects::PrinterState,
@@ -19,7 +20,6 @@ use tokio::{
     time::interval,
 };
 use tokio_util::sync::CancellationToken;
-use crate::common::test_resource_path;
 
 mod common;
 
@@ -47,7 +47,8 @@ fn no_hardware_mode() {
     let (serial_read_sender, serial_read_receiver) = broadcast::channel(200);
     let (serial_write_sender, serial_write_receiver) = broadcast::channel(200);
 
-    let mut configuration = Configuration::from_file(test_resource_path("default.yaml".to_owned())).expect("Config could not be parsed");
+    let mut configuration = Configuration::from_file(test_resource_path("default.yaml".to_owned()))
+        .expect("Config could not be parsed");
 
     configuration.display.frame_buffer = temp_fb.as_os_str().to_str().unwrap().to_owned();
     configuration.config_file = Some(temp_config.as_os_str().to_str().unwrap().to_owned());

--- a/tests/resources/default.yaml
+++ b/tests/resources/default.yaml
@@ -1,0 +1,56 @@
+# This is the default Odyssey configuration file for the Prometheus MSLA. It is
+# meant to be paired with the latest Prometheus MSLA klipper config.
+
+# This section holds the config fields related to the printer, such as its serial
+# connection and its frame buffer specs
+printer:
+  serial: /home/pi/printer_data/comms/klippy.serial
+  baudrate: 0
+  max_z: 300
+  default_lift: 10
+  default_up_speed: 3.4
+  default_down_speed: 3.4
+  default_wait_before_exposure: 2.2
+  default_wait_after_exposure: 1.5
+  pause_lift: 100
+
+# This section holds fields pertaining to the display used by the printer
+display:
+  frame_buffer: /dev/fb0
+  bit_depth:
+    - 5
+    - 6
+    - 5
+  screen_width: 6480
+  screen_height: 3600
+
+# This section holds fields pertaining to the Gcode used to drive the machine's
+# hardware, and signal between the board and Odyssey
+gcode:
+  boot: |
+    G90
+  shutdown: |
+    M84
+    UVLED_OFF
+  home_command: HOME_AXIS
+  move_command: MOVE_PLATE Z={z} F={speed}
+  print_start: |
+    HOME_AXIS
+    SET_PRINT_STATS_INFO TOTAL_LAYER={total_layers}
+  print_end: |
+    MOVE_PLATE Z={max_z} F=400
+  layer_start: SET_PRINT_STATS_INFO CURRENT_LAYER={layer}
+  cure_start: UVLED_ON
+  cure_end: UVLED_OFF
+  move_sync: Z_move_comp
+  move_timeout: 60
+  status_check: status
+  status_desired: "Klipper state: Ready"
+
+# This section holds fields pertaining to the Odyseey API, such as the port number
+# and where to store uploaded .sl1 files
+api:
+  upload_path: /home/pi/printer_data/gcodes
+  # glob pattern for finding files in mounted USB devices, if present
+  usb_glob: /media/usb*/*.sl1
+  port: 12357


### PR DESCRIPTION
Refactor Configuration object with optional_struct usage
Add Config Patch endpoint for changes
Modify Configuration loading/saving to use serde directly and to move pre-existing config to backup when saving changes