### PR TITLE
Api(status): Add /status/stream SSE endpoint 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.64"
 regex = "1"
 serialport = { version = "4.2.0", default-features = false }
 poem = { version = "3.0.0", features = ["websocket", "multipart","sse"]}
-poem-openapi = { version = "5.0.0", features = ["swagger-ui","redoc","rapidoc"] }
+poem-openapi = { version = "5.0.0", features = ["swagger-ui"] }
 glob = "0.3.1"
 log = "0.4.17"
 simple_logger = "4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ simple_logger = "4.1.0"
 tokio-stream = {version="0.1.17",features = ["sync"]}
 tracing = "0.1"
 tracing-subscriber = "0.3"
+async-stream = "0.3.2"
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,14 @@ futures = "0.3.26"
 async-trait = "0.1.64"
 regex = "1"
 serialport = { version = "4.2.0", default-features = false }
-poem = { version = "3.0.0", features = ["websocket", "multipart"]}
+poem = { version = "3.0.0", features = ["websocket", "multipart","sse"]}
 poem-openapi = { version = "5.0.0", features = ["swagger-ui"] }
 glob = "0.3.1"
 log = "0.4.17"
 simple_logger = "4.1.0"
+tokio-stream = {version="0.1.17",features = ["sync"]}
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.64"
 regex = "1"
 serialport = { version = "4.2.0", default-features = false }
 poem = { version = "3.0.0", features = ["websocket", "multipart","sse"]}
-poem-openapi = { version = "5.0.0", features = ["swagger-ui"] }
+poem-openapi = { version = "5.0.0", features = ["swagger-ui","redoc","rapidoc"] }
 glob = "0.3.1"
 log = "0.4.17"
 simple_logger = "4.1.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -143,12 +143,12 @@ impl Api {
     }
     
      #[oai(path = "/events", method = "get")]
-    async fn index(&self) -> EventStream<BoxStream<'static, i32>> {
+    async fn index(&self) -> EventStream<BoxStream<'static, String>> {
         EventStream::new(
             async_stream::stream! {
                 for i in 0.. {
                     tokio::time::sleep(Duration::from_secs(1)).await;
-                    yield i;
+                    yield "wa".to_string();
                 }
             }
             .boxed(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, UNIX_EPOCH},
 };
 
-use futures::{stream::BoxStream};
+use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use glob::glob;
 use itertools::Itertools;
 use poem::{
@@ -34,7 +34,7 @@ use tokio::{
     sync::{broadcast, mpsc, RwLock},
     time::interval,
 };
-use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+use tokio_stream::wrappers::BroadcastStream;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
@@ -176,10 +176,10 @@ impl Api {
                         .ok()
                 },
             ).take(1)*/
-            .filter_map(|result| result.ok())
+            .filter_map(|result| async{result.ok()})
         );
         tracing::info!("built status stream");
-        stream
+        stream.boxed()
     }
 
     #[instrument]

--- a/src/api.rs
+++ b/src/api.rs
@@ -175,7 +175,7 @@ impl Api {
                         })
                         .ok()
                 },
-            ).take(1)
+            )
         );
         tracing::info!("built status stream");
         stream

--- a/src/api.rs
+++ b/src/api.rs
@@ -322,10 +322,8 @@ impl Api {
 
         let bytes = file_upload.file.into_vec().await.map_err(BadRequest)?;
 
-        let mut f = File::create(configuration.upload_path.clone() + "/" + &file_name)
-            .expect("Could not create new file");
-        f.write_all(bytes.as_slice())
-            .expect("Failed to write file contents");
+        let mut f = File::create(configuration.upload_path.clone() + "/" + &file_name).map_err(InternalServerError)?;
+        f.write_all(bytes.as_slice()).map_err(InternalServerError)?;
 
         Ok(())
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -322,7 +322,8 @@ impl Api {
 
         let bytes = file_upload.file.into_vec().await.map_err(BadRequest)?;
 
-        let mut f = File::create(configuration.upload_path.clone() + "/" + &file_name).map_err(InternalServerError)?;
+        let mut f = File::create(configuration.upload_path.clone() + "/" + &file_name)
+            .map_err(InternalServerError)?;
         f.write_all(bytes.as_slice()).map_err(InternalServerError)?;
 
         Ok(())

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, UNIX_EPOCH},
 };
 
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream};
 use glob::glob;
 use itertools::Itertools;
 use poem::{
@@ -34,7 +34,7 @@ use tokio::{
     sync::{broadcast, mpsc, RwLock},
     time::interval,
 };
-use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
@@ -141,19 +141,6 @@ impl Api {
     ) -> Json<PrinterState> {
         Json(state_ref.read().await.clone())
     }
-    
-     #[oai(path = "/events", method = "get")]
-    async fn index(&self) -> EventStream<BoxStream<'static, String>> {
-        EventStream::new(
-            async_stream::stream! {
-                for i in 0.. {
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    yield "wa".to_string();
-                }
-            }
-            .boxed(),
-        )
-    }
 
     #[instrument]
     #[oai(path = "/status/stream", method = "get")]
@@ -189,7 +176,7 @@ impl Api {
                         .ok()
                 },
             ).take(1)*/
-            .filter_map(|result| async{result.ok()})
+            .filter_map(|result| result.ok())
         );
         tracing::info!("built status stream");
         stream

--- a/src/api.rs
+++ b/src/api.rs
@@ -141,6 +141,19 @@ impl Api {
     ) -> Json<PrinterState> {
         Json(state_ref.read().await.clone())
     }
+    
+     #[oai(path = "/events", method = "get")]
+    async fn index(&self) -> EventStream<BoxStream<'static, i32>> {
+        EventStream::new(
+            async_stream::stream! {
+                for i in 0.. {
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    yield i;
+                }
+            }
+            .boxed(),
+        )
+    }
 
     #[instrument]
     #[oai(path = "/status/stream", method = "get")]

--- a/src/api.rs
+++ b/src/api.rs
@@ -161,7 +161,7 @@ impl Api {
         state_receiver: &Arc<broadcast::Receiver<PrinterState>>,
     ) -> BoxStream<'static, PrinterState> {
         let stream = Box::pin(
-            BroadcastStream::new(state_receiver.resubscribe()).filter_map(
+            BroadcastStream::new(state_receiver.resubscribe())/* .filter_map(
                 |status_result| async move {
                     tracing::info!("{:?}", status_result);
                     status_result
@@ -175,7 +175,8 @@ impl Api {
                         })
                         .ok()
                 },
-            )
+            ).take(1)*/
+            .filter_map(|result| async{result.ok()})
         );
         tracing::info!("built status stream");
         stream

--- a/src/display.rs
+++ b/src/display.rs
@@ -47,7 +47,7 @@ impl PrintDisplay {
 
         let chunk_size: u8 = self.config.bit_depth.iter().sum(); //8
         let pixels_per_chunk = self.config.bit_depth.len(); //1
-        log::info!("Re-encoding frame with bit-depth {} into {} pixels in {} bits, with the following bit layout: {:?}", bit_depth, pixels_per_chunk, chunk_size, self.config.bit_depth);
+        tracing::info!("Re-encoding frame with bit-depth {} into {} pixels in {} bits, with the following bit layout: {:?}", bit_depth, pixels_per_chunk, chunk_size, self.config.bit_depth);
 
         let mut new_buffer: Vec<u8> = Vec::new();
 

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -57,7 +57,7 @@ impl Gcode {
 
     async fn send_gcode(&mut self, code: String) -> std::io::Result<()> {
         let parsed_code = self.parse_gcode(code) + "\r\n";
-        log::debug!("Executing gcode: {}", parsed_code.trim_end());
+        tracing::debug!("Executing gcode: {}", parsed_code.trim_end());
 
         self.serial_sender
             .send(parsed_code)
@@ -73,13 +73,13 @@ impl Gcode {
         response: String,
         timeout_seconds: usize,
     ) -> std::io::Result<()> {
-        log::trace!("Expecting response: {}", response);
+        tracing::trace!("Expecting response: {}", response);
         let mut interval = interval(Duration::from_millis(100));
         let intervals = 10 * timeout_seconds;
 
         for _ in 0..intervals {
             if self.check_response(&response).await {
-                log::trace!("Expected response received");
+                tracing::trace!("Expected response received");
                 return Ok(());
             } else {
                 interval.tick().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 use clap::Parser;
 
 use serialport::{ClearBuffer, SerialPort};
-use simple_logger::SimpleLogger;
 use tokio::{
     runtime::{Builder, Runtime},
     sync::{broadcast, mpsc},
@@ -19,6 +18,7 @@ use odyssey::{
     serial_handler,
     shutdown_handler::ShutdownHandler,
 };
+use tracing::{level_filters::LevelFilter, Level};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -35,12 +35,9 @@ fn main() {
 
     let args = parse_cli();
 
-    SimpleLogger::new()
-        .with_level(log::LevelFilter::from_str(&args.loglevel).expect("Unable to parse loglevel"))
-        .init()
-        .unwrap();
+    tracing_subscriber::fmt().with_max_level(LevelFilter::from_str(&args.loglevel).expect("Unable to parse loglevel")).init();
 
-    log::info!("Starting Odyssey");
+    tracing::info!("Starting Odyssey");
 
     let configuration = parse_config(args.config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,9 @@ fn main() {
 
     let args = parse_cli();
 
-    tracing_subscriber::fmt().with_max_level(LevelFilter::from_str(&args.loglevel).expect("Unable to parse loglevel")).init();
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::from_str(&args.loglevel).expect("Unable to parse loglevel"))
+        .init();
 
     tracing::info!("Starting Odyssey");
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -160,7 +160,7 @@ impl<T: HardwareControl> Printer<T> {
         wait_before_exposure: f64,
         wait_after_exposure: f64,
     ) {
-        log::info!("Begin layer {}", layer);
+        tracing::info!("Begin layer {}", layer);
         self.wrapped_start_layer(layer).await;
         let layer_z = ((layer + 1) as u32) * layer_height;
         //let lift_z = layer_z+
@@ -168,27 +168,27 @@ impl<T: HardwareControl> Printer<T> {
         let exposure_time = cur_frame.exposure_time;
 
         // Move the plate up first, then down into position
-        log::info!("Moving to layer position {}", layer_z);
+        tracing::info!("Moving to layer position {}", layer_z);
 
         self.wrapped_move(layer_z + lift, up_speed).await;
         self.wrapped_move(layer_z, down_speed).await;
 
         // Wait for configured time before curing
-        log::info!("Waiting for {}s before cure", wait_before_exposure);
+        tracing::info!("Waiting for {}s before cure", wait_before_exposure);
         sleep(Duration::from_secs_f64(wait_before_exposure)).await;
 
         // Display the current frame to the LCD
-        log::info!("Loading layer to display");
+        tracing::info!("Loading layer to display");
         self.display.display_frame(cur_frame);
 
         // Activate the UV array for the prescribed length of time
-        log::info!("Curing layer for {}s", exposure_time);
+        tracing::info!("Curing layer for {}s", exposure_time);
         self.wrapped_start_cure().await;
         sleep(Duration::from_secs_f64(exposure_time)).await;
         self.wrapped_stop_cure().await;
 
         // Wait for configured time after curing
-        log::info!("Waiting for {}s after cure", wait_after_exposure);
+        tracing::info!("Waiting for {}s after cure", wait_after_exposure);
         sleep(Duration::from_secs_f64(wait_after_exposure)).await;
     }
 
@@ -266,7 +266,7 @@ impl<T: HardwareControl> Printer<T> {
     }
 
     pub async fn start_print(&mut self, file_data: FileMetadata) {
-        log::info!("Starting Print");
+        tracing::info!("Starting Print");
 
         let print_data = Sl1::from_file(file_data).get_metadata();
         self.enter_printing_state(print_data).await;
@@ -279,7 +279,7 @@ impl<T: HardwareControl> Printer<T> {
             self.hardware_controller
                 .remove_print_variable("layer".to_string());
             self.update_idle_state(physical_state).await;
-            log::info!("Print complete.");
+            tracing::info!("Print complete.");
         } else {
             self.shutdown().await;
         }
@@ -328,16 +328,16 @@ impl<T: HardwareControl> Printer<T> {
         let optional_frame = Frame::from_layer(file.get_layer_data(layer).await).await;
 
         if let Some(frame) = optional_frame {
-            log::info!("Loading layer {} from {} to display", layer, file_data.name);
+            tracing::info!("Loading layer {} from {} to display", layer, file_data.name);
             self.display.display_frame(frame);
         }
     }
 
     async fn enter_printing_state(&mut self, print_data: PrintMetadata) {
-        log::info!("Entering printing state");
+        tracing::info!("Entering printing state");
         match self.state.status {
             PrinterStatus::Idle => {
-                log::debug!("Transitioning from Idle State");
+                tracing::debug!("Transitioning from Idle State");
                 self.state = PrinterState {
                     print_data: Some(print_data),
                     paused: Some(false),
@@ -347,10 +347,10 @@ impl<T: HardwareControl> Printer<T> {
                 };
             }
             PrinterStatus::Printing => {
-                log::debug!("Already in printing state!");
+                tracing::debug!("Already in printing state!");
             }
             PrinterStatus::Shutdown => {
-                log::debug!("Cannot start print, Odyssey shutdown");
+                tracing::debug!("Cannot start print, Odyssey shutdown");
             }
         }
     }
@@ -406,7 +406,7 @@ impl<T: HardwareControl> Printer<T> {
     }
 
     pub async fn boot(&mut self) {
-        log::info!("Booting up printer.");
+        tracing::info!("Booting up printer.");
 
         let boot_result: Result<PhysicalState, std::io::Error> =
             self.hardware_controller.boot().await;
@@ -419,7 +419,7 @@ impl<T: HardwareControl> Printer<T> {
 
     pub async fn _verify_hardware(&mut self) -> bool {
         if !self.hardware_controller.is_ready().await {
-            log::error!("Hardware controller no longer ready! Shutting down Odyssey");
+            tracing::error!("Hardware controller no longer ready! Shutting down Odyssey");
             self.shutdown().await;
             return false;
         }
@@ -427,13 +427,13 @@ impl<T: HardwareControl> Printer<T> {
     }
 
     pub async fn shutdown(&mut self) {
-        log::info!("Shutting down.");
+        tracing::info!("Shutting down.");
         // If hardware still running, execute shutdown commands
         if self.hardware_controller.is_ready().await {
             if (self.hardware_controller.shutdown().await).is_ok() {
-                log::info!("Shut down gcode executed successfully")
+                tracing::info!("Shut down gcode executed successfully")
             } else {
-                log::info!("Unable to execute shutdown gcode")
+                tracing::info!("Unable to execute shutdown gcode")
             }
         }
         self.state.status = PrinterStatus::Shutdown;

--- a/src/serial_handler.rs
+++ b/src/serial_handler.rs
@@ -32,7 +32,7 @@ pub async fn run_listener(
             },
             Ok(n) => {
                 if n > 0 {
-                    log::debug!("Read {} bytes from serial: {}", n, read_string.trim_end());
+                    tracing::debug!("Read {} bytes from serial: {}", n, read_string.trim_end());
                     sender
                         .send(read_string)
                         .expect("Unable to send message to channel");
@@ -78,6 +78,6 @@ async fn send_serial(serial_port: &mut TTYPort, message: String) -> io::Result<u
         .flush()
         .expect("Unable to flush serial connection");
 
-    log::trace!("Wrote {} bytes", n);
+    tracing::trace!("Wrote {} bytes", n);
     Ok(n)
 }

--- a/src/sl1.rs
+++ b/src/sl1.rs
@@ -78,7 +78,7 @@ pub struct Sl1 {
 impl PrintFile for Sl1 {
     /// Instantiate the Sl1 from the given file
     fn from_file(file_data: FileMetadata) -> Sl1 {
-        log::info!("Loading PrintFile from SL1 {:?}", file_data);
+        tracing::info!("Loading PrintFile from SL1 {:?}", file_data);
 
         let full_path = Path::new(file_data.parent_path.as_str()).join(file_data.path.as_str());
 

--- a/src/wrapped_framebuffer.rs
+++ b/src/wrapped_framebuffer.rs
@@ -16,7 +16,7 @@ impl WrappedFramebuffer {
         match self.frame_buffer.as_mut() {
             Some(fb) => fb.write_frame(frame),
             None => {
-                log::info!("Writing layer to path: {}", self.fb_path);
+                tracing::info!("Writing layer to path: {}", self.fb_path);
                 match OpenOptions::new()
                     .append(true)
                     .open(self.fb_path.clone())
@@ -25,7 +25,7 @@ impl WrappedFramebuffer {
                     Ok(output_file) => {
                         let _ = output_file.write_all(frame);
                     }
-                    Err(e) => log::error!("Error while writing layer: {}", e),
+                    Err(e) => tracing::error!("Error while writing layer: {}", e),
                 }
             }
         }

--- a/tests/no_hardware_mode.rs
+++ b/tests/no_hardware_mode.rs
@@ -30,8 +30,9 @@ mod common;
 fn no_hardware_mode() {
     let shutdown_handler = ShutdownHandler::new();
 
-
-    tracing_subscriber::fmt().with_max_level(Level::TRACE).init();
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .init();
 
     let tmp_file = tempfile::Builder::new()
         .prefix("odysseyTest")


### PR DESCRIPTION
Add new /status/stream endpoint to return printer state changes as
server-sent-events
Switch to Tracing for async log capture that works better with Poem
Fix error handling for certain API endpoints